### PR TITLE
Fix parameter order for HTTP client requests

### DIFF
--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -47,8 +47,15 @@ final class Client
 
         return $settings;
     }
-    public function request(string $url, $method, ?array $options = [])
+    /**
+     * Issue an HTTP request using the underlying Symfony client.
+     *
+     * @param string      $method  HTTP verb such as 'GET' or 'POST'
+     * @param string      $url     Target URL
+     * @param array|null  $options Additional request options
+     */
+    public function request(string $method, string $url, ?array $options = [])
     {
-        return $this->client->request($url, $method, $options);
+        return $this->client->request($method, $url, $options);
     }
 }


### PR DESCRIPTION
## Summary
- document the Client::request method and ensure it forwards method before URL

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685922737a988330bb6b806aa0efbdd8