### PR TITLE
Add mobile menu toggle and VPN/proxy support

### DIFF
--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -158,8 +158,19 @@ class MainController extends Controller
         if ($filename = Helper::getFileName($url)) {
             $this->aria2->setFileName($filename);
         }
+        $vpnStart = Helper::getSettings('ncd_vpn_start');
+        $vpnStop = Helper::getSettings('ncd_vpn_stop');
+        if ($vpnStart) {
+            @exec($vpnStart);
+        }
         if (!($result = $this->aria2->download($url))) {
+            if ($vpnStop) {
+                @exec($vpnStop);
+            }
             return ['error' => 'failed to download the file for some reason!'];
+        }
+        if ($vpnStop) {
+            @exec($vpnStop);
         }
         if (isset($result['error'])) {
             return $result;

--- a/lib/Controller/YtdlController.php
+++ b/lib/Controller/YtdlController.php
@@ -188,7 +188,15 @@ class YtdlController extends Controller
         }
         $this->aria2->setFileName($filename);
 
+        $vpnStart = Helper::getSettings('ncd_vpn_start');
+        $vpnStop = Helper::getSettings('ncd_vpn_stop');
+        if ($vpnStart) {
+            @exec($vpnStart);
+        }
         $result = $this->aria2->download($url);
+        if ($vpnStop) {
+            @exec($vpnStop);
+        }
         if (!$result) {
             return ['error' => 'failed to download the file for some reason!'];
         }

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -51,23 +51,44 @@ class Personal implements ISettings
 				"disallow_aria2_settings" => Helper::getAdminSettings("disallow_aria2_settings"),
 				"is_admin" => \OC_User::isAdminUser($this->uid),
 			],
-			"options" => [
-				[
-					"label" => "Downloads Folder ",
-					"id" => "ncd_downloader_dir",
-					"value" => Helper::getDownloadDir(),
-					"placeholder" => Helper::getDownloadDir() ?? "/downloads",
-					"path"    => $path,
-				],
-				[
-					"label" => "Torrents Folder",
-					"id" => "ncd_torrents_dir",
-					"value" => $this->settings->get("ncd_torrents_dir"),
-					"placeholder" => $this->settings->get("ncd_torrents_dir") ?? "/torrents",
-					"path" => $path,
-				]
-			]
-		];
+                        "options" => [
+                                [
+                                        "label" => "Downloads Folder ",
+                                        "id" => "ncd_downloader_dir",
+                                        "value" => Helper::getDownloadDir(),
+                                        "placeholder" => Helper::getDownloadDir() ?? "/downloads",
+                                        "path"    => $path,
+                                ],
+                                [
+                                        "label" => "Torrents Folder",
+                                        "id" => "ncd_torrents_dir",
+                                        "value" => $this->settings->get("ncd_torrents_dir"),
+                                        "placeholder" => $this->settings->get("ncd_torrents_dir") ?? "/torrents",
+                                        "path" => $path,
+                                ],
+                                [
+                                        "label" => "VPN start command",
+                                        "id" => "ncd_vpn_start",
+                                        "value" => $this->settings->get("ncd_vpn_start"),
+                                        "placeholder" => "/usr/bin/wg-quick up wg0",
+                                        "path" => $path,
+                                ],
+                                [
+                                        "label" => "VPN stop command",
+                                        "id" => "ncd_vpn_stop",
+                                        "value" => $this->settings->get("ncd_vpn_stop"),
+                                        "placeholder" => "/usr/bin/wg-quick down wg0",
+                                        "path" => $path,
+                                ],
+                                [
+                                        "label" => "Download Proxy",
+                                        "id" => "ncd_download_proxy",
+                                        "value" => $this->settings->get("ncd_download_proxy"),
+                                        "placeholder" => "socks5://127.0.0.1:1080",
+                                        "path" => $path,
+                                ]
+                        ]
+                ];
 
 		//\OC_Util::addScript($this->appName, 'common');
 		//\OC_Util::addScript($this->appName, 'settings/personal');

--- a/lib/Tools/Helper.php
+++ b/lib/Tools/Helper.php
@@ -443,11 +443,16 @@ class Helper
 
     public static function getYtdlConfig($uid = null): array
     {
+        $settings = self::newSettings($uid);
         $config = [
             'binary' => self::getAdminSettings("ncd_yt_binary"),
             'downloadDir' => Helper::getRealDownloadDir(),
-            'settings' => self::newSettings()->getYtdl(),
+            'settings' => $settings->getYtdl(),
         ];
+        $proxy = $settings->get("ncd_download_proxy");
+        if ($proxy) {
+            $config['settings']['proxy'] = $proxy;
+        }
         return $config;
     }
 
@@ -465,6 +470,10 @@ class Helper
         $options['seed_ratio'] = $settings->get("ncd_seed_ratio");
         if (is_array($customSettings = $settings->getAria2())) {
             $options = array_merge($customSettings, $options);
+        }
+        $proxy = $settings->get("ncd_download_proxy");
+        if ($proxy) {
+            $options['all-proxy'] = $proxy;
         }
         $token = Helper::getAdminSettings("ncd_aria2_rpc_token");
         $rpcHost = Helper::getAdminSettings("ncd_aria2_rpc_host");

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -3,6 +3,10 @@
 @import 'helpers';
 @import 'navigation';
 
+#app-navigation-toggle {
+    display: none;
+}
+
 #ncdownloader-settings-collapsible-container {
     padding-left: 4%;
 }
@@ -198,6 +202,18 @@
     }
 }
 @media only screen and (max-width: 600px) {
+    #app-navigation-toggle {
+        display: block;
+    }
+    #app-navigation {
+        display: none;
+    }
+    #app-navigation.opened {
+        display: block;
+    }
+    #app-ncdownloader-wrapper {
+        flex-direction: column;
+    }
     #app-navigation:not(.vue) {
         width: 100%;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,12 @@ window.addEventListener('DOMContentLoaded', function () {
             callback(parent, oldHtml, data);
         }).send();
     })
+    eventHandler.add('click', '#app-navigation-toggle', function () {
+        const nav = document.getElementById('app-navigation')
+        if (nav) {
+            nav.classList.toggle('opened')
+        }
+    })
     eventHandler.add("click", "#app-navigation", "#search-download", helper.showDownload);
     delegate('#app-ncdownloader-wrapper',
         { target: '[data-tippy-content]' }

--- a/templates/Index.php
+++ b/templates/Index.php
@@ -6,6 +6,7 @@ extract($_);
 ]);
 ?>
 <div id="app-ncdownloader-wrapper">
+    <button id="app-navigation-toggle" class="icon-menu" aria-controls="app-navigation"></button>
     <?php print_unescaped($this->inc('Navigation'));?>
     <?php print_unescaped($this->inc('Content'));?>
     <div id="app-settings-data" data-search-sites=<?php print $search_sites;?> data-settings='<?php print($settings);?>' ></div>


### PR DESCRIPTION
## Summary
- add hamburger toggle and responsive navigation styles
- allow configuring VPN start/stop commands and download proxy
- pass proxy options to aria2 and yt-dlp

## Testing
- `npm test` *(fails: Undefined variable in Sass bootstrap `_root.scss`)*
- `composer test` *(fails: Command "test" is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_6897720e504083308813666aa743a54e