### PR TITLE
Improve mobile navigation responsiveness

### DIFF
--- a/src/components/mainForm.vue
+++ b/src/components/mainForm.vue
@@ -277,5 +277,19 @@ export default {
       }
     }
   }
+  @media only screen and (max-width: 600px) {
+    #nc-vue-unified-form {
+      height: auto;
+      .options-group,
+      .action-group > div {
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+      }
+      .options-group > .option-buttons {
+        width: 100%;
+      }
+    }
+  }
 }
 </style>

--- a/src/components/textInput.vue
+++ b/src/components/textInput.vue
@@ -47,4 +47,11 @@ export default {
     }
   }
 }
+@media only screen and (max-width: 600px) {
+  #text-input-link {
+    input {
+      font-size: smaller;
+    }
+  }
+}
 </style>

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -197,3 +197,30 @@
         width: 135px;
     }
 }
+@media only screen and (max-width: 600px) {
+    #app-navigation:not(.vue) {
+        width: 100%;
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease-in-out;
+    }
+    body.app-navigation-open #app-navigation:not(.vue) {
+        transform: translateX(0);
+    }
+    #app-navigation:not(.vue) .app-navigation-entry-deleted {
+        transform: translateX(100%);
+    }
+    #app-content-wrapper {
+        flex-direction: column;
+    }
+    #ncdownloader-form-wrapper .form-input-wrapper {
+        flex-direction: column;
+        row-gap: 5px;
+    }
+    #ncdownloader-settings-form input[type=text] {
+        width: 100%;
+    }
+}

--- a/src/css/table.scss
+++ b/src/css/table.scss
@@ -99,3 +99,11 @@
     }
   }
 }
+
+@media only screen and (max-width: 600px) {
+  #ncdownloader-table-wrapper {
+    .table-cell:first-child {
+      width: 100px;
+    }
+  }
+}

--- a/templates/Index.php
+++ b/templates/Index.php
@@ -1,5 +1,9 @@
 <?php
 extract($_);
+\OCP\Util::addHeader('meta', [
+    'name'    => 'viewport',
+    'content' => 'width=device-width, initial-scale=1'
+]);
 ?>
 <div id="app-ncdownloader-wrapper">
     <?php print_unescaped($this->inc('Navigation'));?>


### PR DESCRIPTION
## Summary
- Slide-out navigation now covers entire screen on devices under 600px
- Maintain full-width layout for content and forms on narrow screens

## Testing
- `npm run build` *(fails: SassError: Undefined variable $theme-colors-rgb)*
- `make test` *(fails: Could not download composer dependencies; CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685926118a808330b64e8c7e8f560386