### PR TITLE
Improve mobile navigation responsiveness

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ download videos from 700+ video sites(youtube,youku,vimo,dailymotion,twitter,fac
     <screenshot>https://user-images.githubusercontent.com/3911975/142445020-27ec389a-5437-4d28-acc0-5e757fd6897d.png</screenshot>
     <repository>https://github.com/shiningw/ncdownloader</repository>
     <dependencies>
-        <php min-version="7.3" max-version="8.3" />
+        <php min-version="7.3" max-version="8.4" />
         <nextcloud min-version="20" max-version="31"/>
     </dependencies>
     <navigations>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"@babel/core": "^7.15.0",
 		"@babel/preset-env": "^7.15.0",
 		"@nextcloud/browserslist-config": "^2.2.0",
-		"@nextcloud/dialogs": "^3.1.2",
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/router": "^2.0.0",
 		"@vue/compiler-sfc": "^3.2.20",

--- a/src/components/mainForm.vue
+++ b/src/components/mainForm.vue
@@ -277,5 +277,19 @@ export default {
       }
     }
   }
+  @media only screen and (max-width: 600px) {
+    #nc-vue-unified-form {
+      height: auto;
+      .options-group,
+      .action-group > div {
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+      }
+      .options-group > .option-buttons {
+        width: 100%;
+      }
+    }
+  }
 }
 </style>

--- a/src/components/textInput.vue
+++ b/src/components/textInput.vue
@@ -47,4 +47,11 @@ export default {
     }
   }
 }
+@media only screen and (max-width: 600px) {
+  #text-input-link {
+    input {
+      font-size: smaller;
+    }
+  }
+}
 </style>

--- a/src/css/bootstrap.scss
+++ b/src/css/bootstrap.scss
@@ -1,4 +1,5 @@
 @import "../../node_modules/bootstrap/scss/functions";
 @import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/maps";
 @import "../../node_modules/bootstrap/scss/mixins";
 @import "../../node_modules/bootstrap/scss/root";

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -197,3 +197,30 @@
         width: 135px;
     }
 }
+@media only screen and (max-width: 600px) {
+    #app-navigation:not(.vue) {
+        width: 100%;
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease-in-out;
+    }
+    body.app-navigation-open #app-navigation:not(.vue) {
+        transform: translateX(0);
+    }
+    #app-navigation:not(.vue) .app-navigation-entry-deleted {
+        transform: translateX(100%);
+    }
+    #app-content-wrapper {
+        flex-direction: column;
+    }
+    #ncdownloader-form-wrapper .form-input-wrapper {
+        flex-direction: column;
+        row-gap: 5px;
+    }
+    #ncdownloader-settings-form input[type=text] {
+        width: 100%;
+    }
+}

--- a/src/css/table.scss
+++ b/src/css/table.scss
@@ -99,3 +99,11 @@
     }
   }
 }
+
+@media only screen and (max-width: 600px) {
+  #ncdownloader-table-wrapper {
+    .table-cell:first-child {
+      width: 100px;
+    }
+  }
+}

--- a/templates/Index.php
+++ b/templates/Index.php
@@ -1,5 +1,9 @@
 <?php
 extract($_);
+\OCP\Util::addHeader('meta', [
+    'name'    => 'viewport',
+    'content' => 'width=device-width, initial-scale=1'
+]);
 ?>
 <div id="app-ncdownloader-wrapper">
     <?php print_unescaped($this->inc('Navigation'));?>


### PR DESCRIPTION
## Summary
- Drop unused `@nextcloud/dialogs` to avoid Vue peer dependency conflicts
- Import Bootstrap maps to satisfy `$theme-colors-rgb` during Sass build
- Allow PHP up to 8.4 in app metadata

## Testing
- `npm run build`
- `make test` *(fails: curl error 56 while downloading composer dependencies; CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_685926118a808330b64e8c7e8f560386