### PR TITLE
Add VPN control endpoints and UI hooks

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -14,6 +14,8 @@ return [
         ['name' => 'Ytdl#Delete', 'url' => '/ytdl/delete', 'verb' => 'POST'],
         ['name' => 'Ytdl#Redownload', 'url' => '/ytdl/redownload', 'verb' => 'POST'],
         ['name' => 'Search#Execute', 'url' => '/search', 'verb' => 'POST'],
+        ['name' => 'Vpn#start', 'url' => '/vpn/start', 'verb' => 'POST'],
+        ['name' => 'Vpn#stop', 'url' => '/vpn/stop', 'verb' => 'POST'],
         // AdminSettings
         ['name' => 'Settings#saveAdmin', 'url' => '/admin/save', 'verb' => 'POST'],
         ['name' => 'Settings#saveGlobalAria2', 'url' => '/admin/aria2/save', 'verb' => 'POST'],

--- a/lib/Controller/VpnController.php
+++ b/lib/Controller/VpnController.php
@@ -1,0 +1,62 @@
+<?php
+namespace OCA\NCDownloader\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IConfig;
+use Symfony\Component\Process\Process;
+
+class VpnController extends Controller
+{
+    /** @var IConfig */
+    private $config;
+    private $uid;
+
+    public function __construct(string $appName, IRequest $request, IConfig $config, $UserId)
+    {
+        parent::__construct($appName, $request);
+        $this->config = $config;
+        $this->uid = $UserId;
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function start(): JSONResponse
+    {
+        $cmd = trim($this->config->getUserValue($this->uid, $this->appName, 'vpnStartCmd', ''));
+        if ($cmd === '') {
+            return new JSONResponse(['error' => 'No VPN start command configured']);
+        }
+        return $this->runCommand($cmd);
+    }
+
+    /**
+     * @NoAdminRequired
+     */
+    public function stop(): JSONResponse
+    {
+        $cmd = trim($this->config->getUserValue($this->uid, $this->appName, 'vpnStopCmd', ''));
+        if ($cmd === '') {
+            return new JSONResponse(['error' => 'No VPN stop command configured']);
+        }
+        return $this->runCommand($cmd);
+    }
+
+    private function runCommand(string $cmd): JSONResponse
+    {
+        try {
+            $process = Process::fromShellCommandline($cmd);
+            $process->run();
+            if ($process->isSuccessful()) {
+                $output = trim($process->getOutput());
+                return new JSONResponse(['status' => true, 'message' => $output !== '' ? $output : 'Command executed']);
+            }
+            $error = trim($process->getErrorOutput());
+            return new JSONResponse(['status' => false, 'error' => $error !== '' ? $error : 'Command failed']);
+        } catch (\Throwable $e) {
+            return new JSONResponse(['status' => false, 'error' => $e->getMessage()]);
+        }
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,28 @@ window.addEventListener('DOMContentLoaded', function () {
             callback(parent, oldHtml, data);
         }).send();
     })
+    eventHandler.add("click", "#start-vpn", "button", function (e) {
+        const path = basePath + "/vpn/start";
+        let url = helper.generateUrl(path);
+        helper.httpClient(url).setHandler(function (data) {
+            if (data.error) {
+                helper.error(data.error);
+            } else if (data.message) {
+                helper.info(data.message);
+            }
+        }).send();
+    })
+    eventHandler.add("click", "#stop-vpn", "button", function (e) {
+        const path = basePath + "/vpn/stop";
+        let url = helper.generateUrl(path);
+        helper.httpClient(url).setHandler(function (data) {
+            if (data.error) {
+                helper.error(data.error);
+            } else if (data.message) {
+                helper.info(data.message);
+            }
+        }).send();
+    })
     eventHandler.add('click', '#app-navigation-toggle', function () {
         const nav = document.getElementById('app-navigation')
         if (nav) {

--- a/templates/Navigation.php
+++ b/templates/Navigation.php
@@ -38,6 +38,16 @@ $downloadsList = [
         </button>
         <?php endif;?>
     </div>
+    <div class="app-navigation-new" id="start-vpn">
+        <button type="button" class="icon-power">
+            <?php print $l->t('Start VPN');?>
+        </button>
+    </div>
+    <div class="app-navigation-new" id="stop-vpn">
+        <button type="button" class="icon-close">
+            <?php print $l->t('Stop VPN');?>
+        </button>
+    </div>
     <?php endif;?>
     <ul>
         <?php foreach ($downloadsList as $value): ?>


### PR DESCRIPTION
## Summary
- add `VpnController` to run start/stop commands using Symfony Process
- expose `/vpn/start` and `/vpn/stop` routes
- add Start/Stop VPN buttons and JS handlers

## Testing
- `npm test` *(fails: SassError: Undefined variable and webpack compiled with errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c93b9e09083308694dac56a3aa6ae