### PR TITLE
Adjust app content layout for medium screens

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -201,6 +201,24 @@
         width: 135px;
     }
 }
+
+@media only screen and (max-width: 1020px) {
+    #app-content,
+    #app-content-wrapper {
+        flex       : 1 1 auto;
+        margin-left: 0;
+    }
+
+    #app-content {
+        padding   : var(--body-padding, 16px);
+        box-sizing: border-box;
+    }
+
+    #app-content-wrapper {
+        padding        : var(--body-padding, 16px);
+        box-sizing     : border-box;
+    }
+}
 @media only screen and (max-width: 600px) {
     #app-navigation-toggle {
         display: block;


### PR DESCRIPTION
## Summary
- add a <=1020px breakpoint so #app-content and #app-content-wrapper fill the viewport without the navigation gutter
- give the medium-width layout consistent padding using the existing --body-padding fallback and ensure box sizing stays inside the container

## Testing
- npm run stylelint *(fails: stylelint executable not available in the container)*
- npm run test *(fails: existing Sass build error from bootstrap variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cffe7523d48330b5f05b71f60f979c