### PR TITLE
Rename project to "Net loader", add localized READMEs and update metadata

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,35 @@
+## Net loader (Deutsch)
+
+Eine einfach zu bedienende Weboberfläche für Aria2 und youtube-dl/yt-dlp in Nextcloud.
+
+- Torrents direkt in der App über mehrere BT-Seiten suchen.
+- Aria2 steuern und Download-Aufgaben per Weboberfläche verwalten.
+- yt-dlp für Downloads von vielen Video-Plattformen nutzen.
+
+### Verwendung
+
+Net loader bringt yt-dlp und aria2c bereits mit, daher ist eine manuelle Installation meist nicht nötig.
+Wenn die mitgelieferten Binärdateien in deiner Umgebung nicht funktionieren, installiere sie manuell und hinterlege die Pfade in den Einstellungen.
+
+#### aria2 und yt-dlp unter Ubuntu installieren
+
+```bash
+sudo apt install aria2
+sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
+sudo chmod a+rx /usr/local/bin/yt-dlp
+```
+
+### Frontend bauen
+
+Node.js 14+ und npm 7+ werden benötigt.
+
+```bash
+npm run build
+composer install
+```
+
+### Prüfung der NPM-Paket-Aktualität
+
+Ein aktueller Statusbericht liegt hier:
+
+- `docs/npm-package-status.md`

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,35 @@
+## Net loader (English)
+
+An easy-to-use web interface for Aria2 and youtube-dl/yt-dlp in Nextcloud.
+
+- Search for torrents from multiple BT sites inside the app.
+- Control Aria2 and manage download tasks via web UI.
+- Use yt-dlp for downloads from many video sites.
+
+### How to use
+
+Net loader includes both yt-dlp and aria2c, so manual installation is usually not required.
+If built-in binaries do not work in your environment, install them manually and configure paths in settings.
+
+#### Installing aria2 and yt-dlp on Ubuntu
+
+```bash
+sudo apt install aria2
+sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
+sudo chmod a+rx /usr/local/bin/yt-dlp
+```
+
+### Build front-end code
+
+Node.js 14+ and npm 7+ are required.
+
+```bash
+npm run build
+composer install
+```
+
+### NPM package freshness check
+
+A current package status report is generated in:
+
+- `docs/npm-package-status.md`

--- a/README.md
+++ b/README.md
@@ -1,39 +1,6 @@
-- [English](README.md)
-- [简体中文](README.zh-CN.md)
+## Net loader
 
-An easy-to-use web interface for Aria2 and youtube-dl
+- [English documentation](README.en.md)
+- [Deutsche Dokumentation](README.de.md)
 
-- Search for torrents within the app from mutiple BT sites
-- Control Aria2 and manage download tasks from the web;
-- Harnessing the power of youtube-dl to download videos from 700+ video sites(youtube,youku,dailymotion,twitter,facebook and the likes;
-<img width="800" alt="nc2" src="https://user-images.githubusercontent.com/3911975/132008308-dec2a7ba-4387-441e-9ded-538d61fbccf0.png">
-<img width="800" alt="nc4" src="https://user-images.githubusercontent.com/3911975/142444998-54dd54a6-0c8e-4d49-8188-270964a99c50.png">
-<img width="800" alt="nc5" src="https://user-images.githubusercontent.com/3911975/142445020-27ec389a-5437-4d28-acc0-5e757fd6897d.png">
-
-### How to use
-
-NCDownloader has included both yt-dlp(faster version of youtube-dl) and aria2c and there is no need for manual installation under normal circumstances (*tested it successfully with snap version of nextcloud both in centos7 and ubuntu 20.04*)   
-But if for some reason,the builtin binaries don't work for you, then you will need to install them yourself
-
-#### installing aria2 and yt-dlp in ubuntu
-```bash
-sudo apt install aria2
-sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2022.05.18/yt-dlp 4 -o /usr/local/bin/youtube-dl
-sudo chmod a+rx /usr/local/bin/youtube-dl
-```
-Also, if you don't want to use the builtin versions, you can always force the app use a specific version by setting the binary path manually. In that case, the app will not try to find youtube-dl binary in your system, and the built-in ones will be ignored as well. 
-
-### How to build front-end code
-
-NPM 7.0+ and node 14.0.0+ are required to build front-end scripts
-
-```bash
-#start to build
-npm run build
-
-#installing php dependencies
-composer install
-```
-
-#### Nextcloud App homepage
-https://apps.nextcloud.com/apps/ncdownloader
+This repository provides documentation in English and German.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0"?>
 <info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>ncdownloader</id>
-    <name>NCDownloader</name>
-    <summary>Aria2 and youtube-dl web gui for nextcloud</summary>
+    <name>Net loader</name>
+    <summary>Standalone download manager UI for Nextcloud</summary>
     <description>
 Search for torrents within the app from mutiple BT sites;
 Control Aria2 and manage download tasks from the web;
 download videos from 700+ video sites(youtube,youku,vimo,dailymotion,twitter,facebook and the likes
     </description>
-    <version>1.0.24</version>
+    <version>0.1.0</version>
     <licence>agpl</licence>
     <author mail="freefallbenson@gmail.com" homepage="https://github.com/shiningw">jiaxinhuang</author>
     <namespace>NCDownloader</namespace>
     <category>tools</category>
-    <website>https://github.com/shiningw/ncdownloader</website>
-    <bugs>https://github.com/shiningw/ncdownloader/issues</bugs>
+    <website>https://github.com/net-loader/net-loader</website>
+    <bugs>https://github.com/net-loader/net-loader/issues</bugs>
     <screenshot>https://user-images.githubusercontent.com/3911975/142444998-54dd54a6-0c8e-4d49-8188-270964a99c50.png</screenshot>
     <screenshot>https://user-images.githubusercontent.com/3911975/142445020-27ec389a-5437-4d28-acc0-5e757fd6897d.png</screenshot>
-    <repository>https://github.com/shiningw/ncdownloader</repository>
+    <repository>https://github.com/net-loader/net-loader</repository>
     <dependencies>
         <php min-version="8.1" max-version="8.4" />
         <nextcloud min-version="28" max-version="32"/>
     </dependencies>
     <navigations>
         <navigation>
-            <name>NCDownloader</name>
+            <name>Net loader</name>
             <route>ncdownloader.Main.Index</route>
             <icon>ncdownloader.svg</icon>
         </navigation>

--- a/docs/npm-package-status.md
+++ b/docs/npm-package-status.md
@@ -1,0 +1,42 @@
+# NPM package status
+
+Checked on: 2026-04-24
+
+Legend: **Range includes latest** = whether the current configured version range already allows the current npm latest release.
+
+| Section | Package | Configured Range | Latest on npm | Latest within configured range | Range includes latest |
+|---|---|---:|---:|---:|---|
+| devDependencies | @babel/core | `^7.15.0` | `7.29.0` | `7.29.0` | yes |
+| devDependencies | @babel/preset-env | `^7.15.0` | `7.29.2` | `7.29.2` | yes |
+| devDependencies | @nextcloud/browserslist-config | `^2.2.0` | `3.1.2` | `2.3.0` | no |
+| devDependencies | @nextcloud/dialogs | `^3.1.2` | `7.3.0` | `3.2.0` | no |
+| devDependencies | @nextcloud/l10n | `^1.4.1` | `3.4.1` | `1.6.0` | no |
+| devDependencies | @nextcloud/router | `^2.0.0` | `3.1.0` | `2.2.1` | no |
+| devDependencies | @vue/compiler-sfc | `^3.2.20` | `3.5.33` | `3.5.33` | yes |
+| devDependencies | babel-loader | `^8.2.2` | `10.1.1` | `8.4.1` | no |
+| devDependencies | bootstrap | `^5.1.0` | `5.3.8` | `5.3.8` | yes |
+| dependencies | chalk | `^5.0.0` | `5.6.2` | `5.6.2` | yes |
+| devDependencies | css-loader | `^6.4.0` | `7.1.4` | `6.11.0` | no |
+| devDependencies | html-webpack-plugin | `^5.3.2` | `5.6.7` | `5.6.7` | yes |
+| devDependencies | jquery | `^3.6.0` | `4.0.0` | `3.7.1` | no |
+| devDependencies | mini-css-extract-plugin | `^2.6.0` | `2.10.2` | `2.10.2` | yes |
+| devDependencies | popper.js | `^1.16.1` | `1.16.1` | `1.16.1` | yes |
+| devDependencies | sass | `^1.38.0` | `1.99.0` | `1.99.0` | yes |
+| devDependencies | sass-loader | `^10.2.0` | `16.0.7` | `10.5.2` | no |
+| devDependencies | style-loader | `^3.3.0` | `4.0.0` | `3.3.4` | no |
+| devDependencies | svg-url-loader | `^7.1.1` | `8.0.0` | `7.1.1` | no |
+| devDependencies | svgo-loader | `^3.0.0` | `5.0.0` | `3.0.3` | no |
+| devDependencies | tippy.js | `^6.3.2` | `6.3.7` | `6.3.7` | yes |
+| devDependencies | toastify-js | `^1.11.1` | `1.12.0` | `1.12.0` | yes |
+| dependencies | toastr | `^2.1.4` | `2.1.4` | `2.1.4` | yes |
+| devDependencies | ts-loader | `^9.2.6` | `9.5.7` | `9.5.7` | yes |
+| devDependencies | typescript | `^4.5.5` | `6.0.3` | `4.9.5` | no |
+| devDependencies | url-loader | `^4.1.1` | `4.1.1` | `4.1.1` | yes |
+| dependencies | v-tooltip | `^4.0.0-alpha.1` | `2.1.3` | `4.0.0-beta.17` | no |
+| devDependencies | validator | `^13.6.0` | `13.15.35` | `13.15.35` | yes |
+| devDependencies | vue | `^3.2.20` | `3.5.33` | `3.5.33` | yes |
+| devDependencies | vue-loader | `^16.0.0-beta.10` | `17.4.2` | `16.8.3` | no |
+| devDependencies | vue-svg-loader | `^0.17.0-beta.2` | `0.16.0` | `0.17.0-beta.2` | no |
+| dependencies | vuex | `^4.0.2` | `4.1.0` | `4.1.0` | yes |
+| devDependencies | webpack | `^5.69.0` | `5.106.2` | `5.106.2` | yes |
+| devDependencies | webpack-cli | `^4.9.0` | `7.0.2` | `4.10.0` | no |

--- a/lib/Search/Sites/searchBase.php
+++ b/lib/Search/Sites/searchBase.php
@@ -34,7 +34,7 @@ abstract class searchBase
         return $this;
     }
 
-    protected function addActionLinks(array $links = null)
+    protected function addActionLinks(?array $links = null)
     {
         $links = $links ?? $this->actionLinks;
         foreach ($this->rows as $key => &$value) {

--- a/lib/Settings/AdminSection.php
+++ b/lib/Settings/AdminSection.php
@@ -30,7 +30,7 @@ class AdminSection implements IIconSection {
 	}
 
 	public function getName(): string {
-		return $this->l->t('NCDownloader Settings');
+		return $this->l->t('Net loader Settings');
 	}
 
 	public function getPriority(): int {

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -30,7 +30,7 @@ class PersonalSection implements IIconSection {
 	}
 
 	public function getName(): string {
-		return $this->l->t('NCDownloader Settings');
+		return $this->l->t('Net loader Settings');
 	}
 
 	public function getPriority(): int {

--- a/lib/Tools/ExecutableFinder.php
+++ b/lib/Tools/ExecutableFinder.php
@@ -46,7 +46,7 @@ class ExecutableFinder
      *
      * @return string|null
      */
-    public function find(string $name, string $default = null, array $extraDirs = [])
+    public function find(string $name, ?string $default = null, array $extraDirs = [])
     {
         if (ini_get('open_basedir')) {
             $searchPath = array_merge(explode(\PATH_SEPARATOR, ini_get('open_basedir')), $extraDirs);

--- a/package.json
+++ b/package.json
@@ -1,76 +1,76 @@
 {
-	"name": "ncdownloader",
-	"description": "Nextcloud Frontend for youtube-dl and Aria2",
-	"version": "1.0.0",
-	"author": "Jiaxin Huang <freefallbenson@gmail.com>",
-	"contributors": [
-		"Jiaxin Huang <freefallbenson@gmail.com>"
-	],
-	"keywords": [
-		"nextcloud",
-		"ncdownloader",
-		"app",
-		"dev"
-	],
-	"bugs": {
-		"url": "https://github.com/shiningw/ncdownloader/issues"
-	},
-	"repository": {
-		"url": "https://github.com/shiningw/ncdownloader",
-		"type": "git"
-	},
-	"homepage": "https://github.com/shiningw/ncdownloader",
-	"license": "agpl",
-	"private": true,
-	"scripts": {
-		"build": "NODE_ENV=production webpack --progress --config webpack.app.js",
-		"test": "NODE_ENV=development webpack --progress --config webpack.app.js",
-		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.app.js",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
-		"stylelint": "stylelint src",
-		"stylelint:fix": "stylelint src --fix"
-	},
-	"dependencies": {
-		"chalk": "^5.0.0",
-		"toastr": "^2.1.4",
-		"v-tooltip": "^4.0.0-alpha.1",
-		"vuex": "^4.0.2"
-	},
-	"engines": {
-		"node": ">=14.0.0",
-		"npm": ">=7.0.0"
-	},
-	"devDependencies": {
-		"@babel/core": "^7.15.0",
-		"@babel/preset-env": "^7.15.0",
-		"@nextcloud/browserslist-config": "^2.2.0",
-		"@nextcloud/dialogs": "^3.1.2",
-		"@nextcloud/l10n": "^1.4.1",
-		"@nextcloud/router": "^2.0.0",
-		"@vue/compiler-sfc": "^3.2.20",
-		"babel-loader": "^8.2.2",
-		"bootstrap": "^5.1.0",
-		"css-loader": "^6.4.0",
-		"html-webpack-plugin": "^5.3.2",
-		"jquery": "^3.6.0",
-		"mini-css-extract-plugin": "^2.6.0",
-		"popper.js": "^1.16.1",
-		"sass": "^1.38.0",
-		"sass-loader": "^10.2.0",
-		"style-loader": "^3.3.0",
-		"svg-url-loader": "^7.1.1",
-		"svgo-loader": "^3.0.0",
-		"tippy.js": "^6.3.2",
-		"toastify-js": "^1.11.1",
-		"ts-loader": "^9.2.6",
-		"typescript": "^4.5.5",
-		"url-loader": "^4.1.1",
-		"validator": "^13.6.0",
-		"vue": "^3.2.20",
-		"vue-loader": "^16.0.0-beta.10",
-		"vue-svg-loader": "^0.17.0-beta.2",
-		"webpack": "^5.69.0",
-		"webpack-cli": "^4.9.0"
-	}
+  "name": "net-loader",
+  "description": "Standalone Nextcloud frontend for yt-dlp and aria2",
+  "version": "0.1.0",
+  "author": "Jiaxin Huang <freefallbenson@gmail.com>",
+  "contributors": [
+    "Jiaxin Huang <freefallbenson@gmail.com>"
+  ],
+  "keywords": [
+    "nextcloud",
+    "net-loader",
+    "app",
+    "dev"
+  ],
+  "bugs": {
+    "url": "https://github.com/net-loader/net-loader/issues"
+  },
+  "repository": {
+    "url": "https://github.com/net-loader/net-loader",
+    "type": "git"
+  },
+  "homepage": "https://github.com/net-loader/net-loader",
+  "license": "agpl",
+  "private": true,
+  "scripts": {
+    "build": "NODE_ENV=production webpack --progress --config webpack.app.js",
+    "test": "NODE_ENV=development webpack --progress --config webpack.app.js",
+    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.app.js",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "eslint --ext .js,.vue src --fix",
+    "stylelint": "stylelint src",
+    "stylelint:fix": "stylelint src --fix"
+  },
+  "dependencies": {
+    "chalk": "^5.0.0",
+    "toastr": "^2.1.4",
+    "v-tooltip": "^4.0.0-alpha.1",
+    "vuex": "^4.0.2"
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@nextcloud/browserslist-config": "^2.2.0",
+    "@nextcloud/dialogs": "^3.1.2",
+    "@nextcloud/l10n": "^1.4.1",
+    "@nextcloud/router": "^2.0.0",
+    "@vue/compiler-sfc": "^3.2.20",
+    "babel-loader": "^8.2.2",
+    "bootstrap": "^5.1.0",
+    "css-loader": "^6.4.0",
+    "html-webpack-plugin": "^5.3.2",
+    "jquery": "^3.6.0",
+    "mini-css-extract-plugin": "^2.6.0",
+    "popper.js": "^1.16.1",
+    "sass": "^1.38.0",
+    "sass-loader": "^10.2.0",
+    "style-loader": "^3.3.0",
+    "svg-url-loader": "^7.1.1",
+    "svgo-loader": "^3.0.0",
+    "tippy.js": "^6.3.2",
+    "toastify-js": "^1.11.1",
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.5.5",
+    "url-loader": "^4.1.1",
+    "validator": "^13.6.0",
+    "vue": "^3.2.20",
+    "vue-loader": "^16.0.0-beta.10",
+    "vue-svg-loader": "^0.17.0-beta.2",
+    "webpack": "^5.69.0",
+    "webpack-cli": "^4.9.0"
+  }
 }


### PR DESCRIPTION
### Motivation

- Rebrand the application from `NCDownloader` to `Net loader` and centralize documentation in English and German. 
- Provide an up-to-date NPM dependency status report to track frontend package ranges. 
- Apply small type-safety and localization text updates for consistency across code and metadata.

### Description

- Added localized documentation files `README.en.md` and `README.de.md` and simplified `README.md` to point to the two language docs. 
- Updated application metadata in `appinfo/info.xml` and `package.json` including `name`, `version`, `description`, repository and issue URLs, and navigation/setting labels to reflect the `Net loader` rename. 
- Added `docs/npm-package-status.md` containing a snapshot check of configured NPM ranges versus latest package versions. 
- Made minor code changes: changed `searchBase::addActionLinks(array $links = null)` to `addActionLinks(?array $links = null)`, changed `ExecutableFinder::find(string $name, string $default = null, array $extraDirs = [])` to accept `?string $default`, and updated settings section display names in `AdminSection` and `PersonalSection`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb38e549308327829d7c072c33c820)