### PR TITLE
Fix null queryBuilder access in YtdlController

### DIFF
--- a/lib/Controller/YtdlController.php
+++ b/lib/Controller/YtdlController.php
@@ -24,7 +24,6 @@ class YtdlController extends Controller
     private $ytdl;
     private $aria2;
     private $urlGenerator;
-    private $tablename;
     private $dataDir;
 
     public function __construct($appName, IRequest $request, $UserId, IL10N $IL10N, Aria2 $aria2, Ytdl $ytdl)
@@ -39,7 +38,6 @@ class YtdlController extends Controller
         $this->ytdl = $ytdl;
         $this->aria2 = $aria2;
         $this->aria2->init();
-        $this->tablename = $this->dbconn->queryBuilder->getTableName("ncdownloader_info");
     }
     /**
      * @NoAdminRequired


### PR DESCRIPTION
### Motivation
- Fix the crash `Call to a member function getTableName() on null` caused by the controller accessing the internal `queryBuilder`, and enforce that DB access is performed via the `Db\Helper` layer rather than controller internals.

### Description
- Remove the unused `private $tablename;` property and the constructor line that called `$this->dbconn->queryBuilder->getTableName("ncdownloader_info");`, so the controller no longer touches `queryBuilder` and relies on `Db\Helper` methods for DB operations.

### Testing
- Ran `php -l lib/Controller/YtdlController.php` and `php -l lib/Db/Helper.php`, and both files passed PHP lint with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49362bb08327bbdca2949c46bb44)