### PR TITLE
Validate gid and make Delete/Redownload accept optional param; remove unused tablename init

### DIFF
--- a/lib/Controller/YtdlController.php
+++ b/lib/Controller/YtdlController.php
@@ -24,7 +24,6 @@ class YtdlController extends Controller
     private $ytdl;
     private $aria2;
     private $urlGenerator;
-    private $tablename;
     private $dataDir;
 
     public function __construct($appName, IRequest $request, $UserId, IL10N $IL10N, Aria2 $aria2, Ytdl $ytdl)
@@ -39,7 +38,6 @@ class YtdlController extends Controller
         $this->ytdl = $ytdl;
         $this->aria2 = $aria2;
         $this->aria2->init();
-        $this->tablename = $this->dbconn->queryBuilder->getTableName("ncdownloader_info");
     }
     /**
      * @NoAdminRequired
@@ -119,14 +117,17 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Delete(string $gid)
+    public function Delete(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
 
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!isset($data['pid'])) {
             if ($this->dbconn->deleteByGid($gid)) {
@@ -154,13 +155,16 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Redownload(string $gid)
+    public function Redownload(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!empty($data['link'])) {
             if (isset($data['ext'])) {


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and improve robustness when `gid` is not provided or missing from the database by validating inputs and returning clear JSON errors. 
- Allow `Delete` and `Redownload` to be invoked without a direct parameter so they can fallback to request parameters. 
- Remove an unused `tablename` initialization in the constructor to avoid holding unnecessary state.

### Description
- Removed the unused `$this->tablename` initialization from the constructor in `lib/Controller/YtdlController.php`.
- Changed signatures of `Delete` and `Redownload` to accept nullable parameters: `public function Delete(?string $gid = null)` and `public function Redownload(?string $gid = null)`.
- Added fallback to read `gid` from the request via `$gid = $gid ?? $this->request->getParam('gid');` in both methods.
- Added checks for missing database rows or missing `data` and return JSON error messages when the `gid` is not found before proceeding with stop/delete logic.

### Testing
- Performed a PHP syntax check using `php -l` on the modified file and it reported no syntax errors.
- Ran the existing automated test suite with `vendor/bin/phpunit` and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49362bb08327bbdca2949c46bb44)