### PR TITLE
YtdlController: accept request params, validate inputs, and guard DB lookups

### DIFF
--- a/lib/Controller/YtdlController.php
+++ b/lib/Controller/YtdlController.php
@@ -24,7 +24,6 @@ class YtdlController extends Controller
     private $ytdl;
     private $aria2;
     private $urlGenerator;
-    private $tablename;
     private $dataDir;
 
     public function __construct($appName, IRequest $request, $UserId, IL10N $IL10N, Aria2 $aria2, Ytdl $ytdl)
@@ -39,7 +38,6 @@ class YtdlController extends Controller
         $this->ytdl = $ytdl;
         $this->aria2 = $aria2;
         $this->aria2->init();
-        $this->tablename = $this->dbconn->queryBuilder->getTableName("ncdownloader_info");
     }
     /**
      * @NoAdminRequired
@@ -81,16 +79,21 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Download(string $url, ?string $extension = "mp4")
+    public function Download(?string $url = null, ?string $extension = null)
     {
+        $url = $url ?? $this->request->getParam('url') ?? $this->request->getParam('text-input-value');
+        $extension = $extension ?? $this->request->getParam('extension') ?? "mp4";
+        $extension = trim((string) $extension) ?: "mp4";
+        if (!$url || !is_string($url)) {
+            return new JSONResponse(['error' => "no url value is received!"]);
+        }
         $dlDir = $this->ytdl->getDownloadDir();
         if (!is_writable($dlDir)) {
             return new JSONResponse(['error' => sprintf("%s is not writable", $dlDir)]);
         }
-        //$url = trim($this->request->getParam('text-input-value'));
         $url = trim($url);
         $yt = $this->ytdl;
-        if (in_array($extension, $this->audio_extensions)) {
+        if (in_array($extension, $this->audio_extensions, true)) {
             $yt->audioOnly = true;
             $yt->audioFormat = $extension;
         } else {
@@ -119,14 +122,17 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Delete(string $gid)
+    public function Delete(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
 
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!isset($data['pid'])) {
             if ($this->dbconn->deleteByGid($gid)) {
@@ -154,13 +160,16 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Redownload(string $gid)
+    public function Redownload(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!empty($data['link'])) {
             if (isset($data['ext'])) {


### PR DESCRIPTION
### Motivation
- Make the ytdl controller methods more robust by accepting parameters from the request and validating inputs to avoid runtime errors.
- Provide clearer error responses when downloads, download directories, or DB records are missing or invalid.

### Description
- Changed method signatures for `Download`, `Delete`, and `Redownload` to accept nullable parameters and fall back to request parameters when absent, using `?string` defaults.
- Added extraction and validation of `url` and `extension` in `Download`, including trimming, defaulting to `"mp4"`, and returning an error when `url` is missing or not a string.
- Validated download directory writability with `is_writable` and kept the check for installed `yt-dlp`, and used strict `in_array(..., true)` for extension checks.
- Added defensive checks in `Delete` and `Redownload` to return a clear error when the DB row or its `data` is not found, and kept existing process-stop and delete logic intact.
- Minor cleanup: removed an unused `$tablename` initialization and ensured `folderScan::sync()` is called after downloads.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49362bb08327bbdca2949c46bb44)