### PR TITLE
Improve YtdlController input validation and update DB helper QueryBuilder usage

### DIFF
--- a/lib/Controller/YtdlController.php
+++ b/lib/Controller/YtdlController.php
@@ -24,7 +24,6 @@ class YtdlController extends Controller
     private $ytdl;
     private $aria2;
     private $urlGenerator;
-    private $tablename;
     private $dataDir;
 
     public function __construct($appName, IRequest $request, $UserId, IL10N $IL10N, Aria2 $aria2, Ytdl $ytdl)
@@ -39,7 +38,6 @@ class YtdlController extends Controller
         $this->ytdl = $ytdl;
         $this->aria2 = $aria2;
         $this->aria2->init();
-        $this->tablename = $this->dbconn->queryBuilder->getTableName("ncdownloader_info");
     }
     /**
      * @NoAdminRequired
@@ -81,16 +79,21 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Download(string $url, ?string $extension = "mp4")
+    public function Download(?string $url = null, ?string $extension = null)
     {
+        $url = $url ?? $this->request->getParam('url') ?? $this->request->getParam('text-input-value');
+        $extension = $extension ?? $this->request->getParam('extension') ?? "mp4";
+        $extension = trim((string) $extension) ?: "mp4";
+        if (!$url || !is_string($url)) {
+            return new JSONResponse(['error' => "no url value is received!"]);
+        }
         $dlDir = $this->ytdl->getDownloadDir();
         if (!is_writable($dlDir)) {
             return new JSONResponse(['error' => sprintf("%s is not writable", $dlDir)]);
         }
-        //$url = trim($this->request->getParam('text-input-value'));
         $url = trim($url);
         $yt = $this->ytdl;
-        if (in_array($extension, $this->audio_extensions)) {
+        if (in_array($extension, $this->audio_extensions, true)) {
             $yt->audioOnly = true;
             $yt->audioFormat = $extension;
         } else {
@@ -119,14 +122,17 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Delete(string $gid)
+    public function Delete(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
 
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!isset($data['pid'])) {
             if ($this->dbconn->deleteByGid($gid)) {
@@ -154,13 +160,16 @@ class YtdlController extends Controller
     /**
      * @NoAdminRequired
      */
-    public function Redownload(string $gid)
+    public function Redownload(?string $gid = null)
     {
-        //$gid = $this->request->getParam('gid');
+        $gid = $gid ?? $this->request->getParam('gid');
         if (!$gid) {
             return new JSONResponse(['error' => "no gid value is received!"]);
         }
         $row = $this->dbconn->getByGid($gid);
+        if (!$row || !isset($row['data'])) {
+            return new JSONResponse(['error' => sprintf("%s was not found in database!", $gid)]);
+        }
         $data = $this->dbconn->getExtra($row["data"]);
         if (!empty($data['link'])) {
             if (isset($data['ext'])) {

--- a/lib/Db/Helper.php
+++ b/lib/Db/Helper.php
@@ -1,7 +1,7 @@
 <?php
 namespace OCA\NCDownloader\Db;
 use OCA\NCDownloader\Tools\Helper as ToolsHelper;
-use OCP\DB\IQueryBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 
 class Helper
 {
@@ -34,6 +34,11 @@ class Helper
             ->from($this->table)
             ->executeQuery();
         return $queryBuilder->fetchAllAssociative();
+    }
+
+    public function getTableName(): string
+    {
+        return $this->conn->getQueryBuilder()->getTableName($this->table);
     }
 
     public function getByUid($uid)

--- a/lib/Ytdl/Helper.php
+++ b/lib/Ytdl/Helper.php
@@ -18,7 +18,7 @@ class Helper
     public function __construct()
     {
         $this->dbconn = new DbHelper();
-        $this->tablename = $this->dbconn->queryBuilder->getTableName("ncdownloader_info");
+        $this->tablename = $this->dbconn->getTableName();
         $this->user = \OC::$server->get(\OCP\IUserSession::class)->getUser()->getUID();
     }
 


### PR DESCRIPTION
### Motivation

- Normalize and harden input handling for ytdl endpoints and avoid direct access to internal query builder state to support newer Nextcloud DB APIs.

### Description

- Update `YtdlController` to accept nullable parameters for `Download`, `Delete`, and `Redownload`, read fallback values from request parameters, and return clear JSON errors when required inputs are missing.
- Add validation and sanitization for `url` and `extension` in `Download`, ensure `extension` defaults to `mp4`, and use strict `in_array(..., true)` when checking audio extensions.
- Add safety checks when deleting or redownloading entries to return an error if the database row or `data` field is missing, and keep existing process termination and deletion logic intact.
- Replace direct `queryBuilder->getTableName(...)` usage by exposing a `getTableName()` method on `Db\Helper` and update `Ytdl\Helper` and other callers to use it; also update DB QueryBuilder import to `OCP\DB\QueryBuilder\IQueryBuilder` for parameter constants compatibility.

### Testing

- Ran PHP syntax checks with `php -l` on modified files and no syntax errors were reported.
- Ran the existing PHPUnit suite with `vendor/bin/phpunit` against the codebase and the suite completed without failures on the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49362bb08327bbdca2949c46bb44)