### PR TITLE
Fix missing folder selection control in download form

### DIFF
--- a/src/components/folderSettings.vue
+++ b/src/components/folderSettings.vue
@@ -1,19 +1,31 @@
 <template>
-  <div
+  <button
+    type="button"
     @click="handler"
     class="downloader-folder-settings"
     data-tippy-content="Set Download Folder"
     :data-path="path"
-  ></div>
+    :title="title"
+    :aria-label="title"
+  >
+    <span class="folder-icon" aria-hidden="true"></span>
+    <span class="folder-label">Folder</span>
+  </button>
 </template>
 <script>
+import { translate as t } from "@nextcloud/l10n";
 import helper from "../utils/helper";
 
 export default {
   name: "folderSettings",
+  computed: {
+    title() {
+      return t("ncdownloader", "Set Download Folder");
+    },
+  },
   methods: {
     handler(event) {
-      let element = event.target;
+      let element = event.currentTarget;
       const cb = function (path) {
         let dlPath = element.getAttribute("data-path");
         if (dlPath == path) {
@@ -43,11 +55,47 @@ export default {
 </script>
 <style scoped lang="scss">
 @use "../css/variables.scss" as *;
+
 .downloader-folder-settings {
-  width: 45px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-width: 45px;
   height: 100%;
-  background: $bg-color url("../../img/folder.svg") bottom left no-repeat;
-  background-size: 40px 40px;
-  background-clip: border-box;
+  padding: 0 12px;
+  border: 1px solid var(--color-border, #5a5a5a);
+  border-radius: 0;
+  background-color: var(--color-background-dark, #202020);
+  color: var(--color-main-text, #fff);
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    background-color: var(--color-primary-element-light, #3c5a80);
+  }
+}
+
+.folder-icon {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background: center / contain no-repeat url("../../img/folder.svg");
+}
+
+.folder-label {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1;
+}
+
+@media only screen and (max-width: 768px) {
+  .downloader-folder-settings {
+    padding: 0 10px;
+  }
+
+  .folder-label {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
### Motivation
- The folder picker in the download action row was implemented as a bare `<div>` which made it invisible/unreliable to click in some layouts (notably YouTube download mode on desktop and mobile). 
- The change aims to make the folder selection control consistently visible, clickable and accessible. 

### Description
- Replace the empty `<div>` with an explicit `<button>` in `src/components/folderSettings.vue` and add an icon + label so the control is visible. 
- Use `event.currentTarget` in the click handler to reliably read the `data-path` attribute even when the user clicks the icon or label. 
- Add `title`/`aria-label` using `@nextcloud/l10n` for localization and improve styling (border, contrast, icon sprite, responsive behavior that hides the label on small screens). 

### Testing
- Ran `npm run lint`, which failed in this environment because ESLint v9 requires an `eslint.config.js` and the repo uses the legacy config. 
- Ran `npm run build`, which failed due to an existing `sass-loader`/webpack configuration mismatch (unknown `api` option) causing the build to error out.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb594b3a2c83278c6cd12edd936c93)