### PR TITLE
Convert folder settings to accessible button, improve layout and UI styles

### DIFF
--- a/src/components/folderSettings.vue
+++ b/src/components/folderSettings.vue
@@ -1,19 +1,34 @@
 <template>
-  <div
+  <button
+    type="button"
     @click="handler"
     class="downloader-folder-settings"
     data-tippy-content="Set Download Folder"
     :data-path="path"
-  ></div>
+    :title="title"
+    :aria-label="title"
+  >
+    <span class="folder-icon" aria-hidden="true"></span>
+    <span class="folder-label">{{ buttonLabel }}</span>
+  </button>
 </template>
 <script>
+import { translate as t } from "@nextcloud/l10n";
 import helper from "../utils/helper";
 
 export default {
   name: "folderSettings",
+  computed: {
+    title() {
+      return t("ncdownloader", "Set Download Folder");
+    },
+    buttonLabel() {
+      return t("ncdownloader", "Folder");
+    },
+  },
   methods: {
     handler(event) {
-      let element = event.target;
+      let element = event.currentTarget;
       const cb = function (path) {
         let dlPath = element.getAttribute("data-path");
         if (dlPath == path) {
@@ -43,11 +58,49 @@ export default {
 </script>
 <style scoped lang="scss">
 @use "../css/variables.scss" as *;
+
 .downloader-folder-settings {
-  width: 45px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-width: 48px;
   height: 100%;
-  background: $bg-color url("../../img/folder.svg") bottom left no-repeat;
-  background-size: 40px 40px;
-  background-clip: border-box;
+  padding: 0 12px !important;
+  border: 1px solid var(--color-border, #5a5a5a) !important;
+  border-radius: var(--border-radius-element, 4px);
+  background-color: var(--color-main-background, #fff) !important;
+  color: var(--color-main-text, #222) !important;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover,
+  &:focus {
+    background-color: var(--color-background-hover, #eef4f8) !important;
+  }
+}
+
+.folder-icon {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  background: center / contain no-repeat url("../../img/folder.svg");
+}
+
+.folder-label {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1;
+}
+
+@media only screen and (max-width: 768px) {
+  .downloader-folder-settings {
+    min-width: 44px;
+    padding: 0 10px !important;
+  }
+
+  .folder-label {
+    display: none;
+  }
 }
 </style>

--- a/src/components/mainForm.vue
+++ b/src/components/mainForm.vue
@@ -202,6 +202,9 @@ export default {
       }
       & > div[class$="-controls-container"] {
         display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
         & div,
         & select {
           height: 100%;
@@ -283,7 +286,7 @@ export default {
       }
       & > div[class$="-controls-container"] {
         display: flex;
-        justify-content: center;
+        justify-content: flex-start;
       }
     }
   }

--- a/src/css/navigation.scss
+++ b/src/css/navigation.scss
@@ -75,7 +75,7 @@
 
 	width: $navigation-width;
 	z-index: 500;
-	overflow-y: auto;
+	overflow-y: hidden;
 	overflow-x: hidden;
 	background-color: var(--color-main-background-blur);
 	backdrop-filter: var(--filter-background-blur);

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -11,6 +11,52 @@
 #app-ncdownloader-wrapper {
     width: 100%;
     display: flex;
+    min-height: 100%;
+    border-radius: var(--border-radius-large, 12px);
+    overflow: hidden;
+
+    #app-content,
+    #app-content-wrapper,
+    .ncdownloader-body-wrapper,
+    #ncdownloader-form-wrapper,
+    #ncdownloader-table-wrapper {
+        background: transparent;
+    }
+
+    #app-content {
+        background-color: rgba(255, 255, 255, 0.72);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+    }
+
+    #app-navigation:not(.vue) {
+        border-right: 1px solid var(--color-border, #d8d8d8);
+
+        .app-navigation-new {
+            padding: calc(var(--default-grid-baseline) * 1.5);
+        }
+
+        .app-navigation-new button {
+            border-radius: var(--border-radius-element, 8px);
+            background-color: var(--color-main-background, #fff);
+            color: var(--color-main-text, #222);
+        }
+
+        > ul {
+            padding-top: calc(var(--default-grid-baseline) * 1.5);
+            gap: 2px;
+        }
+
+        .download-queue > a {
+            padding-left: 44px;
+            border-radius: var(--border-radius-element, 8px);
+        }
+
+        .download-queue .number {
+            background-color: var(--color-background-darker, #5f5853);
+            color: var(--color-main-text, #fff);
+        }
+    }
 
     .action-item {
         position: relative;
@@ -52,7 +98,7 @@
         background-image: url('../../img/clippy.svg');
     }
     #ncdownloader-form-wrapper {
-        margin-left: 2px;
+        margin-left: 0;
 
         .form-input-wrapper {
             display  : flex;


### PR DESCRIPTION
### Motivation
- Improve accessibility and discoverability of the folder picker control by converting it from a bare `div` into a proper `button` with `title` and `aria-label` and a visible label/icon.
- Fix unreliable event handling by using the correct event target when opening the file picker and ensure the selected path is read reliably.
- Modernize and theme UI visuals with more consistent button styling, responsive layout tweaks, and navigation/content backdrop/spacing improvements.
- Tweak form layout to better handle wrapping and alignment of control groups on different screen sizes.

### Description
- Replaced the folder settings `div` with a semantic `button` and added child spans for an icon and visible label, plus `:title` and `:aria-label` bound to computed translations using `translate` (`t`).
- Added computed properties `title` and `buttonLabel` that call `t("ncdownloader", ...)` for localized button text.
- Replaced use of `event.target` with `event.currentTarget` in the `handler` to reliably reference the button element when invoking the file picker and reading `data-path`.
- Overhauled CSS for `.downloader-folder-settings` to an inline-flex button with padding, border, hover state, an explicit `.folder-icon` using the folder SVG, and `.folder-label` with responsive hiding under `768px`.
- Adjusted layout rules in `mainForm.vue` to allow wrapping of controls (`flex-wrap`, `align-items`, `gap`) and changed `justify-content` for the action group controls to `flex-start` for better alignment.
- Updated `navigation.scss` to change `#app-navigation` vertical overflow from `auto` to `hidden`.
- Enhanced global styling in `style.scss` to add rounded containers, backdrop blur on content, navigation item styling, small spacing and visual tweaks, and reset `#ncdownloader-form-wrapper` left margin.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb594b3a2c83278c6cd12edd936c93)